### PR TITLE
Enable building with Nix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    branches:
+      - language-server
+  push:
+    branches:
+      - language-server
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Build with Nix
+        run: nix build .

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cabal.sandbox.config
 travis.log
 .envrc
 .direnv
+result

--- a/README.md
+++ b/README.md
@@ -12,6 +12,46 @@ A language server should be *fast* and *reliable*. The Elm compiler is both of t
 - 🔍 Find references
 - 🛡️ Diagnostics (errors and warnings)
 
+
+## Try it out quickly via Nix
+
+If you have Nix installed and flakes enabled (which is the default when
+installing with the [Determinate Systems Installer][ds-nix]), you can easily
+compile and run this project without installing it or its build tools.
+
+First, run the following command to make sure your system is able to fetch and
+build everything. This could take a few minutes the first time you run it:
+
+    nix run https://github.com/WhileTruu/elm-language-server -- --help
+
+You should see a bunch of activity as Nix downloads and builds things, and then
+a short message from the language server, like this:
+
+    Start the Elm language server:
+
+        elm-language-server
+
+    The server listens on stdin.
+
+Great! It works. Now, pick one of the following methods to make your
+IDE/editor's LSP integration use the language server:
+
+1. Configure your IDE to use this command for the Elm language server:
+
+       nix run https://github.com/WhileTruu/elm-language-server
+
+2. For an editor that inherits environment from your command line, you can also
+   start a sub-shell with `elm-language-server` available in `PATH`, and then
+   start your editor from within that shell. For instance, by running:
+
+       nix shell https://github.com/WhileTruu/elm-language-server
+       nvim ./src/Main.elm
+
+   You may need to alter your settings to use `elm-language-server` as the
+   elmls command in your LSP configuration.
+
+[ds-nix]: https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#determinate-nix-installer
+
 ## Install
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ compile and run this project without installing it or its build tools.
 First, run the following command to make sure your system is able to fetch and
 build everything. This could take a few minutes the first time you run it:
 
-    nix run https://github.com/WhileTruu/elm-language-server -- --help
+    nix run github:WhileTruu/elm-language-server -- --help
 
 You should see a bunch of activity as Nix downloads and builds things, and then
 a short message from the language server, like this:
@@ -38,13 +38,13 @@ IDE/editor's LSP integration use the language server:
 
 1. Configure your IDE to use this command for the Elm language server:
 
-       nix run https://github.com/WhileTruu/elm-language-server
+       nix run github:WhileTruu/elm-language-server
 
 2. For an editor that inherits environment from your command line, you can also
    start a sub-shell with `elm-language-server` available in `PATH`, and then
    start your editor from within that shell. For instance, by running:
 
-       nix shell https://github.com/WhileTruu/elm-language-server
+       nix shell github.com:WhileTruu/elm-language-server
        nvim ./src/Main.elm
 
    You may need to alter your settings to use `elm-language-server` as the

--- a/elm-language-server.cabal
+++ b/elm-language-server.cabal
@@ -3,13 +3,12 @@ Name: elm-language-server
 Version: 0.3
 
 Synopsis:
-    The `elm` command line interface.
+    Fork of the Elm compiler, repurposed for a language server.
 
 Description:
-    This includes commands like `elm make`, `elm repl`, and many others
-    for helping make Elm developers happy and productive.
+    An experimental language server implementation for the Elm programming language.
 
-Homepage: https://elm-lang.org
+Homepage: https://github.com/WhileTruu/elm-language-server
 
 License: BSD3
 License-file: LICENSE

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749573549,
+        "narHash": "sha256-HlZKrl9I0DE5rqtH6cyzQDPZd9B74Do5LNVljAmyA5E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6242bddfe463a76edf89306d6f11b8cc41ffb58d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749573549,
-        "narHash": "sha256-HlZKrl9I0DE5rqtH6cyzQDPZd9B74Do5LNVljAmyA5E=",
+        "lastModified": 1749747924,
+        "narHash": "sha256-jKQUHC9ufIkhjPMUQRn+ZlN5mvYbZDS8hkltoWtdUco=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6242bddfe463a76edf89306d6f11b8cc41ffb58d",
+        "rev": "ea0962d5c9a0f78014c63b82847c33efa003b4fd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.05";
     utils.url = "github:numtide/flake-utils";
   };
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    utils,
+  }:
+    utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in rec {
+        packages.elm-language-server = (pkgs.callPackage (import ./nix) {}).elm-language-server;
+        defaultPackage = packages.elm-language-server;
+      }
+    );
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,6 @@
+# To update Elm Language Server nixpkg metadata
+
+Switch to this directory and run `./update.sh` to update the Nix package's
+metadata from the cabal file.
+
+This Nix build is based on the Elm compiler's build in NixOS/nixpkgs.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  lib,
+  makeWrapper,
+}: let
+  # Haskell packages that require ghc 9.6
+  hs96Pkgs = import ./packages {inherit pkgs lib makeWrapper;};
+
+  assembleScope = self: basics:
+    (hs96Pkgs self).elmPkgs // basics;
+in
+  lib.makeScope pkgs.newScope
+  (
+    self: assembleScope self {}
+  )

--- a/nix/packages/ansi-wl-pprint/default.nix
+++ b/nix/packages/ansi-wl-pprint/default.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, ansi-terminal, base, fetchgit, lib }:
+mkDerivation {
+  pname = "ansi-wl-pprint";
+  version = "0.6.8.1";
+  src = fetchgit {
+    url = "https://github.com/ekmett/ansi-wl-pprint";
+    sha256 = "00pgxgkramz6y1bgdlm00rsh6gd6mdaqllh6riax2rc2sa35kip4";
+    rev = "d16e2f6896d76b87b72af7220c2e93ba15c53280";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ ansi-terminal base ];
+  homepage = "http://github.com/ekmett/ansi-wl-pprint";
+  description = "The Wadler/Leijen Pretty Printer for colored ANSI terminal output";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -19,8 +19,6 @@ pkgs.haskell.packages.ghc96.override {
         maintainers = with lib.maintainers; [];
         mainProgram = "elm-language-server";
       }) (self.callPackage ./elm-language-server {});
-
-      elmVersion = elmPkgs.elm-language-server.version;
     };
   in
     elmPkgs

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,34 @@
+{
+  pkgs,
+  lib,
+  makeWrapper,
+}: self:
+pkgs.haskell.packages.ghc96.override {
+  overrides = self: super: let
+    inherit (pkgs.haskell.lib.compose) overrideCabal;
+    elmPkgs = rec {
+      elm-language-server = overrideCabal (drv: {
+        # sadly parallelism most of the time breaks compilation
+        enableParallelBuilding = false;
+        patches = [];
+        buildTools = drv.buildTools or [] ++ [makeWrapper];
+
+        description = "Fork of the elm compiler, repurposed for a language server.";
+        homepage = "https://github.com/WhileTruu/elm-language-server";
+        license = lib.licenses.bsd3;
+        maintainers = with lib.maintainers; [];
+        mainProgram = "elm-language-server";
+      }) (self.callPackage ./elm-language-server {});
+
+      elmVersion = elmPkgs.elm-language-server.version;
+    };
+  in
+    elmPkgs
+    // {
+      inherit elmPkgs;
+
+      ansi-wl-pprint = overrideCabal (drv: {
+        jailbreak = true;
+      }) (self.callPackage ./ansi-wl-pprint {});
+    };
+}

--- a/nix/packages/elm-language-server/default.nix
+++ b/nix/packages/elm-language-server/default.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, base, binary
+, bytestring, containers, directory, edit-distance, file-embed
+, filelock, filepath, ghc-prim, haskeline, HTTP, http-client
+, http-client-tls, http-types, language-glsl, lib, mtl, network
+, parsec, process, raw-strings-qq, scientific, SHA, snap-core
+, snap-server, template-haskell, time, unordered-containers
+, utf8-string, vector, zip-archive
+}:
+mkDerivation {
+  pname = "elm-language-server";
+  version = "0.3";
+  src = ../../..;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson ansi-terminal ansi-wl-pprint base binary bytestring
+    containers directory edit-distance file-embed filelock filepath
+    ghc-prim haskeline HTTP http-client http-client-tls http-types
+    language-glsl mtl network parsec process raw-strings-qq scientific
+    SHA snap-core snap-server template-haskell time
+    unordered-containers utf8-string vector zip-archive
+  ];
+  homepage = "https://github.com/WhileTruu/elm-language-server";
+  description = "Fork of the Elm compiler, repurposed for a language server";
+  license = lib.licenses.bsd3;
+  mainProgram = "elm-language-server";
+}

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p cabal2nix elm2nix -i bash
+#!nix-shell -p cabal2nix -i bash
 cd packages/elm-language-server
 cabal2nix ../../.. >default.nix

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p cabal2nix elm2nix -i bash
 cd packages/elm-language-server
-cabal2nix ../../.. --revision 69eed5f91108b74f2bea675917a72c96d01531a7 >default.nix
+cabal2nix ../../.. >default.nix

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p cabal2nix elm2nix -i bash
+cd packages/elm-language-server
+cabal2nix ../../.. --revision 69eed5f91108b74f2bea675917a72c96d01531a7 >default.nix


### PR DESCRIPTION
Enable easily building and running this project by using a Nix flake. This should make it a lot easier for people to try out the project.

I've included a generic GitHub workflow based on [Determinate Systems's example](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#as-a-github-action), enabled only for the `language-server` branch since it looks like that's this project's primary branch.

Let me know your thoughts and if you'd like me to change anything.

